### PR TITLE
feat: add metadata generation for project pages

### DIFF
--- a/src/app/(pec)/projects/[slug]/page.tsx
+++ b/src/app/(pec)/projects/[slug]/page.tsx
@@ -4,12 +4,46 @@ import {
   SINGLE_PROJECT_RESULT,
 } from "@/features/projects/lib/queries";
 import { ProjectView } from "@/features/projects/ui/view/single-project-view";
+import { urlFor } from "@/sanity/lib/image";
 import { sanityFetch } from "@/sanity/lib/live";
+import { Metadata, ResolvingMetadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
 interface Props {
   params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata(
+  { params }: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  const { slug } = await params;
+
+  const {
+    data: project,
+  }: {
+    data: SINGLE_PROJECT_RESULT;
+  } = await sanityFetch({
+    query: SINGLE_PROJECT_QUERY,
+    params: {
+      slug,
+    },
+  });
+
+  return {
+    title: project.title,
+    description: project.description,
+    openGraph: {
+      title: project.title,
+      description: project.description,
+      images: [
+        {
+          url: urlFor(project.mainImage).format("webp").url() || "",
+        },
+      ],
+    },
+  };
 }
 
 export default async function Page({ params }: Props) {
@@ -36,4 +70,3 @@ export default async function Page({ params }: Props) {
     </Suspense>
   );
 }
- 


### PR DESCRIPTION
- Implemented generateMetadata function to fetch and return project-specific metadata.
- Enhanced SEO by including title, description, and Open Graph data based on project details.
- Utilized urlFor to format the main image URL for optimal display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced project pages with dynamic metadata, including improved titles, descriptions, and Open Graph images for better sharing and SEO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->