### PR TITLE
fix: adjust image quality in project metadata generation

### DIFF
--- a/src/app/(pec)/projects/[slug]/page.tsx
+++ b/src/app/(pec)/projects/[slug]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata(
       description: project.description,
       images: [
         {
-          url: urlFor(project.mainImage).format("webp").url() || "",
+          url: urlFor(project.mainImage).format("webp").quality(50).url() || "",
         },
       ],
     },


### PR DESCRIPTION
- Updated the image URL generation in the generateMetadata function to set the quality to 50 for the main project image.
- This change aims to optimize image loading and improve performance on project pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the quality settings for project images used in Open Graph previews, potentially enhancing image loading performance and appearance when sharing project links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->