### PR TITLE
feat: add new publication types to schema

### DIFF
--- a/src/sanity/schemaTypes/publication.ts
+++ b/src/sanity/schemaTypes/publication.ts
@@ -39,6 +39,8 @@ export default defineType({
       type: "string",
       options: {
         list: [
+          { title: "Certification", value: "certification" },
+          { title: "Company Profile", value: "company-profile" },
           { title: "Report", value: "report" },
           { title: "Policy Brief", value: "policy-brief" },
           { title: "Research Paper", value: "research-paper" },


### PR DESCRIPTION
- Introduced "Certification" and "Company Profile" options to the publication schema type.
- Enhanced the list of publication types to provide more flexibility in content categorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added two new publication categories—Certification and Company Profile.
  * These appear at the top of the category selector in the editor.
  * Existing categories remain unchanged; no impact on current entries.
  * Category-based lists, filters, and displays will recognize the new categories once selected.
  * No other fields or workflows were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->